### PR TITLE
[Discover] [PoC] Add initialTabState to doc viewer setExpandedDoc action

### DIFF
--- a/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
+++ b/src/platform/plugins/shared/discover/public/application/main/components/layout/discover_documents.tsx
@@ -9,6 +9,8 @@
 
 import React, { memo, useCallback, useMemo, useRef, useState } from 'react';
 import {
+  EuiButton,
+  EuiFlexGroup,
   EuiFlexItem,
   EuiLoadingSpinner,
   EuiProgress,
@@ -219,11 +221,15 @@ function DiscoverDocumentsComponent({
   const setExpandedDocAction = useCurrentTabAction(internalStateActions.setExpandedDoc);
 
   const setExpandedDoc = useCallback(
-    (doc: DataTableRecord | undefined, options?: { initialTabId?: string }) => {
+    (
+      doc: DataTableRecord | undefined,
+      options?: { initialTabId?: string; initialTabState?: DocViewerRestorableState }
+    ) => {
       dispatch(
         setExpandedDocAction({
           expandedDoc: doc,
           initialDocViewerTabId: options?.initialTabId,
+          initialTabState: options?.initialTabState,
         })
       );
       if (options?.initialTabId) {
@@ -455,10 +461,39 @@ function DiscoverDocumentsComponent({
     [isDataLoading, styles.progress]
   );
 
+  // Demo button to test initial state feature
+  const demoInitialStateButton = useMemo(() => {
+    if (!rows.length) return null;
+
+    return (
+      <EuiButton
+        size="s"
+        color="accent"
+        iconType="beaker"
+        onClick={() => {
+          const firstDoc = rows[0];
+          setExpandedDoc(firstDoc, {
+            initialTabId: 'test',
+            initialTabState: { test: { count: 42 } },
+          });
+        }}
+      >
+        Demo: Open with Initial State (count: 42)
+      </EuiButton>
+    );
+  }, [rows, setExpandedDoc]);
+
   const renderCustomToolbarWithElements = useMemo(
     () =>
       getRenderCustomToolbarWithElements({
-        leftSide: isDataGridFullScreen ? undefined : viewModeToggle,
+        leftSide: isDataGridFullScreen ? undefined : (
+          <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
+            {viewModeToggle && <EuiFlexItem grow={false}>{viewModeToggle}</EuiFlexItem>}
+            {demoInitialStateButton && (
+              <EuiFlexItem grow={false}>{demoInitialStateButton}</EuiFlexItem>
+            )}
+          </EuiFlexGroup>
+        ),
         bottomSection: (
           <>
             {callouts}
@@ -466,7 +501,7 @@ function DiscoverDocumentsComponent({
           </>
         ),
       }),
-    [viewModeToggle, callouts, loadingIndicator, isDataGridFullScreen]
+    [viewModeToggle, demoInitialStateButton, callouts, loadingIndicator, isDataGridFullScreen]
   );
 
   if (isDataViewLoading || (isEmptyDataResult && isDataLoading)) {

--- a/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
+++ b/src/platform/plugins/shared/discover/public/application/main/state_management/redux/internal_state.ts
@@ -27,6 +27,7 @@ import { dismissFlyouts, DiscoverFlyouts } from '@kbn/discover-utils';
 import type { IKbnUrlStateStorage } from '@kbn/kibana-utils-plugin/public';
 import type { ESQLControlVariable } from '@kbn/esql-types';
 import type { DiscoverSession } from '@kbn/saved-search-plugin/common';
+import type { DocViewerRestorableState } from '@kbn/unified-doc-viewer';
 import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { DiscoverCustomizationContext } from '../../../../customizations';
 import type { DiscoverServices } from '../../../../build_services';
@@ -167,6 +168,7 @@ export const internalStateSlice = createSlice({
       action: TabAction<{
         expandedDoc: DataTableRecord | undefined;
         initialDocViewerTabId?: string;
+        initialTabState?: Partial<DocViewerRestorableState>;
       }>
     ) => {
       withTab(state, action.payload, (tab) => {
@@ -178,6 +180,13 @@ export const internalStateSlice = createSlice({
 
         tab.expandedDoc = action.payload.expandedDoc;
         tab.initialDocViewerTabId = action.payload.initialDocViewerTabId;
+
+        if (action.payload.initialTabState) {
+          tab.uiState.docViewer = {
+            ...tab.uiState.docViewer,
+            ...action.payload.initialTabState,
+          };
+        }
       });
     },
 

--- a/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
+++ b/src/platform/plugins/shared/discover/public/components/discover_grid_flyout/discover_grid_flyout.tsx
@@ -14,7 +14,11 @@ import { isOfAggregateQueryType } from '@kbn/es-query';
 import type { DataTableRecord } from '@kbn/discover-utils/types';
 import type { DocViewFilterFn } from '@kbn/unified-doc-viewer/types';
 import type { DataTableColumnsMeta } from '@kbn/unified-data-table';
-import type { DocViewerProps, DocViewsRegistry } from '@kbn/unified-doc-viewer';
+import type {
+  DocViewerProps,
+  DocViewerRestorableState,
+  DocViewsRegistry,
+} from '@kbn/unified-doc-viewer';
 import { DiscoverFlyouts, dismissAllFlyoutsExceptFor } from '@kbn/discover-utils';
 import { UnifiedDocViewerFlyout } from '@kbn/unified-doc-viewer-plugin/public';
 import { useDiscoverServices } from '../../hooks/use_discover_services';
@@ -46,7 +50,10 @@ export interface DiscoverGridFlyoutProps
   onClose: () => void;
   onFilter?: DocViewFilterFn;
   onRemoveColumn: (column: string) => void;
-  setExpandedDoc: (doc?: DataTableRecord, options?: { initialTabId?: string }) => void;
+  setExpandedDoc: (
+    doc?: DataTableRecord,
+    options?: { initialTabId?: string; initialTabState?: DocViewerRestorableState }
+  ) => void;
 }
 
 /**

--- a/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/components/doc_viewer_flyout/doc_viewer_flyout.tsx
@@ -31,7 +31,7 @@ import type { DataTableRecord, DataTableColumnsMeta } from '@kbn/discover-utils/
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import type { ToastsStart } from '@kbn/core-notifications-browser';
 import type { DocViewFilterFn, DocViewRenderProps } from '@kbn/unified-doc-viewer/types';
-import type { DocViewerProps } from '@kbn/unified-doc-viewer';
+import type { DocViewerProps, DocViewerRestorableState } from '@kbn/unified-doc-viewer';
 import { UnifiedDocViewer } from '../lazy_doc_viewer';
 import { useFlyoutA11y } from './use_flyout_a11y';
 
@@ -66,7 +66,10 @@ export interface UnifiedDocViewerFlyoutProps
   onClose: () => void;
   onFilter?: DocViewFilterFn;
   onRemoveColumn: (column: string) => void;
-  setExpandedDoc: (doc?: DataTableRecord) => void;
+  setExpandedDoc: (
+    doc?: DataTableRecord,
+    options?: { initialTabId?: string; initialTabState?: DocViewerRestorableState }
+  ) => void;
   initialTabId?: string;
 }
 

--- a/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
+++ b/src/platform/plugins/shared/unified_doc_viewer/public/plugin.tsx
@@ -11,7 +11,7 @@ import React from 'react';
 import type { CoreSetup, Plugin } from '@kbn/core/public';
 import { i18n } from '@kbn/i18n';
 import { DocViewsRegistry } from '@kbn/unified-doc-viewer';
-import { EuiDelayRender, EuiSkeletonText } from '@elastic/eui';
+import { EuiButton, EuiDelayRender, EuiSkeletonText, EuiSpacer } from '@elastic/eui';
 import { createGetterSetter, Storage } from '@kbn/kibana-utils-plugin/public';
 import type { DataPublicPluginStart } from '@kbn/data-plugin/public';
 import type { FieldFormatsStart } from '@kbn/field-formats-plugin/public';
@@ -20,6 +20,7 @@ import { dynamic } from '@kbn/shared-ux-utility';
 import type { FieldsMetadataPublicStart } from '@kbn/fields-metadata-plugin/public';
 import type { SharePluginStart } from '@kbn/share-plugin/public';
 import type { DiscoverSharedPublicStart } from '@kbn/discover-shared-plugin/public';
+import { createRestorableStateProvider } from '@kbn/restorable-state';
 import type { UnifiedDocViewerServices } from './types';
 
 export const [getUnifiedDocViewerServices, setUnifiedDocViewerServices] =
@@ -88,6 +89,34 @@ export class UnifiedDocViewerPublicPlugin
           />
         );
       },
+    });
+
+    interface TestDocViewRestorableState {
+      count: number;
+    }
+
+    const { withRestorableState, useRestorableState } =
+      createRestorableStateProvider<TestDocViewRestorableState>();
+
+    const Test = withRestorableState(() => {
+      const [count, setCount] = useRestorableState('count', 0);
+      return (
+        <>
+          <EuiSpacer size="s" />
+          <div>Count: {count}</div>
+          <EuiSpacer size="s" />
+          <EuiButton color="text" size="s" onClick={() => setCount(count + 1)}>
+            Increment
+          </EuiButton>
+        </>
+      );
+    });
+
+    this.docViewsRegistry.add({
+      id: 'test',
+      title: 'Test',
+      order: 30,
+      component: Test,
     });
 
     return {


### PR DESCRIPTION
## Summary

PoC of optional requirement from [[Discover] Support restorable state for doc viewer flyout tabs](https://github.com/elastic/kibana/issues/248564#top): Discover profiles can pass `initialTabState` to their doc viewer tabs when calling the `setExpandedDoc` extension point action.

### Checklist

Check the PR satisfies following conditions. 

Reviewers should verify this PR satisfies this list as well.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/src/platform/packages/shared/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This was checked for breaking HTTP API changes, and any breaking changes have been approved by the breaking-change committee. The `release_note:breaking` label should be applied in these situations.
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] The PR  description includes the appropriate Release Notes section, and the correct `release_note:*` label is applied per the [guidelines](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
- [ ] Review the [backport guidelines](https://docs.google.com/document/d/1VyN5k91e5OVumlc0Gb9RPa3h1ewuPE705nRtioPiTvY/edit?usp=sharing) and apply applicable `backport:*` labels.

### Identify risks

Does this PR introduce any risks? For example, consider risks like hard to test bugs, performance regression, potential of data loss.

Describe the risk, its severity, and mitigation for each identified risk. Invite stakeholders and evaluate how to proceed before merging.

- [ ] [See some risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx)
- [ ] ...



